### PR TITLE
Add missing copy_string call

### DIFF
--- a/module.jai
+++ b/module.jai
@@ -208,7 +208,8 @@ parse_tree :: (using p: *XMLParser) {
             }
             {
                 node_push(.pcdata);
-                cursor.value = lexer_accept_until(p, #char "<");
+                value := lexer_accept_until(p, #char "<");
+                cursor.value = copy_string(value);
                 node_pop();
             }
             continue;


### PR DESCRIPTION
Previously the pcdata node's value wasn't copied and thus pointed to a location in the string passed to xml_parse.